### PR TITLE
fix(canary): bump runtime_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_synthetics_canary" "canary" {
   execution_role_arn   = aws_iam_role.canary_role.arn
   handler              = "pageLoadBlueprint.handler"
   zip_file             = "/tmp/${each.key}-${md5(local.file_content[each.key])}.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.9"
+  runtime_version      = "syn-nodejs-puppeteer-6.1"
   start_canary         = true
   tags                 = module.labels.tags
 


### PR DESCRIPTION
## what
* Updated runtime_version for the canary due to the current version being deprecated as of [January 8, 2024](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library.html)

## why
* Terraform throws an error if you use the old runtime_version

## references
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library.html
