### PR TITLE
chore: add security policy and standardize pre-commit and release config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,29 @@
 repos:
-
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
     hooks:
-      - id: terraform-fmt
-      - id: shellcheck
-      - id: tflint
-
+      - id: terraform_fmt
+      - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+      - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0 # Use the ref you want to point at
+    rev: v5.0.0
     hooks:
+      - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: mixed-line-ending
-      - id: check-byte-order-marker
-      - id: check-executables-have-shebangs
-      - id: check-merge-conflict
-      - id: debug-statements
-      - id: check-yaml
-      - id: check-added-large-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing
+
+We welcome contributions! This document provides guidelines for contributing to this project.
+
+## Code of Conduct
+
+Please be respectful and constructive. We are committed to providing a welcoming and inclusive experience for everyone.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a feature branch from `master`
+4. Make your changes
+5. Test your changes
+6. Submit a pull request
+
+## Development Setup
+
+### Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.10.0
+- [pre-commit](https://pre-commit.com/#install)
+- [TFLint](https://github.com/terraform-linters/tflint)
+- [terraform-docs](https://terraform-docs.io/)
+
+### Local Development
+
+```bash
+# Install pre-commit hooks
+pre-commit install
+
+# Run all pre-commit checks
+pre-commit run -a
+
+# Format code
+terraform fmt -recursive
+
+# Validate module
+terraform init -backend=false
+terraform validate
+```
+
+## Pull Request Process
+
+### Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). All commit messages and PR titles must follow this format:
+
+```
+type: description
+```
+
+**Allowed types:** `fix`, `feat`, `docs`, `ci`, `chore`, `test`, `refactor`, `style`, `perf`, `build`, `revert`
+
+**Examples:**
+- `feat: add support for custom tags`
+- `fix: correct subnet CIDR calculation`
+- `docs: update usage examples`
+- `ci: pin workflow actions to SHA`
+
+### PR Checklist
+
+- [ ] Code follows the existing style and conventions
+- [ ] Updated or added examples in `examples/` directory
+- [ ] Ran `pre-commit run -a` locally
+- [ ] Updated documentation if needed
+- [ ] All CI checks pass
+
+### What to Include
+
+- Clear description of what changed and why
+- Link to any related issues
+- Example usage if adding new features
+- Test evidence (terraform validate output, plan output)
+
+## Module Structure
+
+```
+module/
+├── main.tf           # Primary resources
+├── variables.tf      # Input variables
+├── outputs.tf        # Output values
+├── versions.tf       # Provider and Terraform version constraints
+├── locals.tf         # Local values (if needed)
+├── data.tf           # Data sources (if needed)
+├── examples/         # Usage examples
+│   ├── basic/        # Minimal working example
+│   └── complete/     # Full-featured example
+├── README.md         # Documentation (auto-generated)
+├── README.yaml       # Documentation source
+└── CHANGELOG.md      # Version history
+```
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backwards compatible)
+- **PATCH**: Bug fixes (backwards compatible)
+
+## Questions?
+
+Open an issue or reach out at **support@clouddrove.com**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| Latest  | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a security vulnerability, please report it responsibly.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. Email us at **support@clouddrove.com** with:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+2. You will receive an acknowledgment within **48 hours**
+
+3. We will investigate and provide a timeline for a fix
+
+### Response Timeline
+
+| Severity | Acknowledgment | Fix Target |
+|----------|---------------|------------|
+| Critical | 24 hours      | 7 days     |
+| High     | 48 hours      | 14 days    |
+| Medium   | 72 hours      | 30 days    |
+| Low      | 1 week        | Next release |
+
+### Scope
+
+This policy applies to:
+- Terraform module code
+- Example configurations
+- CI/CD workflows
+- Documentation containing sensitive patterns
+
+### Out of Scope
+
+- Vulnerabilities in Terraform itself (report to HashiCorp)
+- Vulnerabilities in cloud provider APIs
+- Issues in third-party dependencies (report upstream)
+
+## Security Best Practices
+
+When using our modules:
+- Always pin module versions in production
+- Review `tfsec` and `checkov` findings before deploying
+- Use least-privilege IAM policies
+- Enable encryption at rest and in transit where available
+- Regularly update to the latest module version


### PR DESCRIPTION
## Summary
- Add SECURITY.md with vulnerability reporting policy
- Add CONTRIBUTING.md with development guidelines
- Add .releaserc.json for semantic-release automation
- Update .editorconfig to match industry standards
- Update .pre-commit-config.yaml to antonbabenko/pre-commit-terraform v1.105.0
- Set provider: none in tf-checks workflow (skip cloud auth for validate-only)
- Fix version constraints if needed

## Test plan
- [ ] Verify pre-commit hooks pass locally
- [ ] Verify CI checks pass
- [ ] Verify terraform validate succeeds